### PR TITLE
Implement URI::to_path() method for converting URIs to filesystem paths

### DIFF
--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -453,6 +453,20 @@ public:
   /// ```
   static auto from_path(const std::filesystem::path &path) -> URI;
 
+  /// Convert a URI to a file system path. For file:// URIs, this correctly
+  /// handles both Windows and UNIX paths. For non-file:// URIs, this returns
+  /// the URI path component. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::core::URI uri{"file:///foo/bar"};
+  /// const auto path{uri.to_path()};
+  /// assert(path.string() == "/foo/bar");
+  /// ```
+  auto to_path() const -> std::filesystem::path;
+
   /// A convenient method to canonicalize and recompose a URI from a string. For
   /// example:
   ///

--- a/src/core/uri/uri.cc
+++ b/src/core/uri/uri.cc
@@ -786,4 +786,59 @@ auto URI::from_path(const std::filesystem::path &path) -> URI {
   return result;
 }
 
+auto URI::to_path() const -> std::filesystem::path {
+  const auto uri_scheme{this->scheme()};
+
+  // Handle file:// URIs specially
+  if (uri_scheme.has_value() && uri_scheme.value() == "file") {
+    const auto uri_host{this->host()};
+    const auto uri_path{this->path()};
+
+    std::ostringstream result;
+
+    // UNC path (Windows network share)
+    if (uri_host.has_value() && !uri_host.value().empty()) {
+      // Decode the host
+      std::istringstream host_input{std::string{uri_host.value()}};
+      std::ostringstream host_output;
+      uri_unescape(host_input, host_output);
+
+      result << "//" << host_output.str();
+
+      if (uri_path.has_value()) {
+        std::istringstream path_input{uri_path.value()};
+        uri_unescape(path_input, result);
+      }
+    } else {
+      // Regular file path
+      if (uri_path.has_value()) {
+        const std::string &path_str = uri_path.value();
+
+        // Check if it's a Windows drive path (e.g., /C:/...)
+        if (path_str.size() >= 3 && path_str[0] == '/' &&
+            std::isalpha(static_cast<unsigned char>(path_str[1])) &&
+            path_str[2] == ':') {
+          // Windows absolute path - skip the leading slash
+          std::istringstream path_input{path_str.substr(1)};
+          uri_unescape(path_input, result);
+        } else {
+          // Unix absolute path or other
+          std::istringstream path_input{path_str};
+          uri_unescape(path_input, result);
+        }
+      }
+    }
+
+    return std::filesystem::path{result.str()};
+  }
+
+  // For non-file:// URIs, return the path component
+  const auto uri_path{this->path()};
+  if (uri_path.has_value()) {
+    return std::filesystem::path{uri_path.value()};
+  }
+
+  return std::filesystem::path{};
+}
+
 } // namespace sourcemeta::core

--- a/test/uri/CMakeLists.txt
+++ b/test/uri/CMakeLists.txt
@@ -6,6 +6,7 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME uri
     uri_host_test.cc
     uri_path_test.cc
     uri_from_path_test.cc
+    uri_to_path_test.cc
     uri_parse_test.cc
     uri_port_test.cc
     uri_scheme_test.cc

--- a/test/uri/uri_to_path_test.cc
+++ b/test/uri/uri_to_path_test.cc
@@ -1,0 +1,137 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/core/uri.h>
+
+TEST(URI_to_path, file_unix_absolute) {
+  const sourcemeta::core::URI uri{"file:///foo/bar/baz"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "/foo/bar/baz");
+}
+
+TEST(URI_to_path, file_unix_with_encoded_space) {
+  const sourcemeta::core::URI uri{"file:///foo/My%20Folder/test"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "/foo/My Folder/test");
+}
+
+TEST(URI_to_path, file_unix_with_encoded_reserved) {
+  const sourcemeta::core::URI uri{"file:///foo/has%23hash%3Fvalue%25"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "/foo/has#hash?value%");
+}
+
+TEST(URI_to_path, file_unix_trailing_slash) {
+  const sourcemeta::core::URI uri{"file:///foo/bar/"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "/foo/bar/");
+}
+
+TEST(URI_to_path, file_windows_drive_absolute) {
+  const sourcemeta::core::URI uri{"file:///C:/Program%20Files/Test"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "C:/Program Files/Test");
+}
+
+TEST(URI_to_path, file_windows_drive_lowercase) {
+  const sourcemeta::core::URI uri{"file:///c:/temp/logs"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "c:/temp/logs");
+}
+
+TEST(URI_to_path, file_windows_drive_root) {
+  const sourcemeta::core::URI uri{"file:///D:/"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "D:/");
+}
+
+TEST(URI_to_path, file_windows_trailing_slash) {
+  const sourcemeta::core::URI uri{"file:///C:/foo/bar/"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "C:/foo/bar/");
+}
+
+TEST(URI_to_path, file_windows_percent_and_plus) {
+  const sourcemeta::core::URI uri{"file:///C:/path/50%25+plus.txt"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "C:/path/50%+plus.txt");
+}
+
+TEST(URI_to_path, file_windows_unc) {
+  const sourcemeta::core::URI uri{"file://server/share/file.txt"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "//server/share/file.txt");
+}
+
+TEST(URI_to_path, file_windows_unc_with_space) {
+  const sourcemeta::core::URI uri{"file://srv/My%20Docs/a%20b.txt"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "//srv/My Docs/a b.txt");
+}
+
+TEST(URI_to_path, file_unicode_unix) {
+  const sourcemeta::core::URI uri{"file:///data/%C3%A9clair.txt"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "/data/éclair.txt");
+}
+
+TEST(URI_to_path, file_unicode_windows) {
+  const sourcemeta::core::URI uri{"file:///C:/data/r%C3%A9sum%C3%A9.doc"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "C:/data/résumé.doc");
+}
+
+TEST(URI_to_path, non_file_http_uri) {
+  const sourcemeta::core::URI uri{"https://www.example.com/foo/bar"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "/foo/bar");
+}
+
+TEST(URI_to_path, non_file_urn) {
+  const sourcemeta::core::URI uri{"urn:example:schema"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "example:schema");
+}
+
+TEST(URI_to_path, non_file_relative_path) {
+  const sourcemeta::core::URI uri{"./foo/bar"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "foo/bar");
+}
+
+TEST(URI_to_path, non_file_absolute_path) {
+  const sourcemeta::core::URI uri{"/foo/bar"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "/foo/bar");
+}
+
+TEST(URI_to_path, empty_uri) {
+  const sourcemeta::core::URI uri{""};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "");
+}
+
+TEST(URI_to_path, fragment_only) {
+  const sourcemeta::core::URI uri{"#foo"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "");
+}
+
+TEST(URI_to_path, file_root) {
+  const sourcemeta::core::URI uri{"file:///"};
+  const auto path{uri.to_path()};
+  EXPECT_EQ(path.string(), "/");
+}
+
+TEST(URI_to_path, roundtrip_unix) {
+  const std::filesystem::path original{"/foo/bar/baz"};
+  const auto uri{sourcemeta::core::URI::from_path(original)};
+  const auto result{uri.to_path()};
+  EXPECT_EQ(result.string(), original.string());
+}
+
+TEST(URI_to_path, roundtrip_unix_with_space) {
+  const std::filesystem::path original{"/foo/My Folder/test"};
+  const auto uri{sourcemeta::core::URI::from_path(original)};
+  const auto result{uri.to_path()};
+  EXPECT_EQ(result.string(), original.string());
+}


### PR DESCRIPTION
## Summary

- Implement new `URI::to_path()` method that converts a URI to a `std::filesystem::path`
- Correctly handle file:// URIs for both Windows and UNIX paths
- Support UNC paths and percent-encoded characters
- For non-file:// URIs, return the URI path component
- Add comprehensive test suite in `test/uri/uri_to_path_test.cc`

## Test plan

- [x] All existing tests pass
- [x] New tests cover Unix absolute paths
- [x] New tests cover Windows drive paths
- [x] New tests cover UNC paths
- [x] New tests cover percent-encoded characters
- [x] New tests cover non-file:// URIs
- [x] Roundtrip tests (from_path -> to_path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)